### PR TITLE
Submodule initialization issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,7 @@ ifneq ($(DEBUG),)
 endif
 
 hotsniper-reliability:
-	git submodule init
-	git submodule update
+	git submodule update --init hotsniper-reliability
 	make -f Makefile.ubuntu-20.04 -C hotsniper-reliability/
 
 configscripts: dependencies

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ ifneq ($(DEBUG),)
 endif
 
 hotsniper-reliability:
-	-git submodule update --init hotsniper-reliabilityX || echo "Warning: cannot retrieve $@ submodule"
-	-make -f Makefile.ubuntu-20.04 -C hotsniper-reliabilityX/ || echo "Warning: cannot compile the $@ submodule"
+	@git submodule update --init hotsniper-reliability || echo "Warning: cannot retrieve $@ submodule"
+	@make -f Makefile.ubuntu-20.04 -C hotsniper-reliability/ || echo "Warning: cannot compile the $@ submodule"
 
 configscripts: dependencies
 	@mkdir -p config

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ ifneq ($(DEBUG),)
 endif
 
 hotsniper-reliability:
-	git submodule update --init hotsniper-reliability
-	make -f Makefile.ubuntu-20.04 -C hotsniper-reliability/
+	-git submodule update --init hotsniper-reliabilityX || echo "Warning: cannot retrieve $@ submodule"
+	-make -f Makefile.ubuntu-20.04 -C hotsniper-reliabilityX/ || echo "Warning: cannot compile the $@ submodule"
 
 configscripts: dependencies
 	@mkdir -p config

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,8 @@ ifneq ($(DEBUG),)
 endif
 
 hotsniper-reliability:
+	git submodule init
+	git submodule update
 	make -f Makefile.ubuntu-20.04 -C hotsniper-reliability/
 
 configscripts: dependencies

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd .. # return to the base Sniper directory (while running inside of Docker)
 
 ### Compiling Sniper
 ```sh
-make # or use 'make -j N' where N is the number of cores in your machine to use parallel make
+make
 ```
 
 


### PR DESCRIPTION
Problem: The `hotsniper-reliability` submodule was not initialized which caused the compilation to fail.

Fix: Added a git command to initialize the `hotsniper-reliability` submodule to the `hotsniper-reliability` rule in `Makefile`. If there is a problem finding the repository or compiling it it will continue compiling sniper as usual.